### PR TITLE
feature: add prefix settings

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,18 @@
-function onClicked(tab) {
-  var prefix = ' » '
+const getSettings = (params) => {
+  return new Promise( (resolve) => {
+    chrome.storage.sync.get(params, (settings) => {
+      resolve(settings);
+    });
+  });
+}
+
+const onClicked = async(tab) => {
+  const settings = await getSettings({
+    prefix: ' \u00BB ',
+  });
+
   var url = 'https://twitter.com/intent/tweet?'
-    + 'text=' + encodeURIComponent(prefix) + encodeURIComponent(tab.title)
+    + 'text=' + encodeURIComponent(settings.prefix) + encodeURIComponent(tab.title)
     + '&url=' + encodeURIComponent(tab.url);
   var w = 640;
   var h = 360;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,12 @@
     "persistent": false,
     "scripts": [ "background.js" ]
   },
+  "options_ui": {
+    "page": "settings/settings.html",
+    "open_in_tab": false
+  },
   "permissions": [
+    "storage",
     "tabs"
   ]
 }

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head><title>Just Tweet Settings</title></head>
+  <body>
+    prefix : <input type="text" id="prefix"/>
+
+    <div id="status"></div>
+    <button id="save">Save</button>
+
+    <script src="settings.js"></script>
+  </body>
+</html>

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1,0 +1,25 @@
+const save_options = () => {
+  const _prefix = document.getElementById('prefix').value;
+
+  chrome.storage.sync.set({
+      prefix: _prefix,
+    }, () => {
+      const status = document.getElementById('status');
+      status.textContent = 'saved!';
+      setTimeout( () => {
+        status.textContent = '';
+      }, 750);
+    }
+  );
+}
+  
+const restore_options = () => {
+    chrome.storage.sync.get({
+      prefix: ' \u00BB '
+    }, (settings) => {
+        document.getElementById('prefix').value = settings.prefix;
+    });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',save_options);


### PR DESCRIPTION
tweetの冒頭に付けるprefixを設定できるようにします。

オプション画面のjsについては、アロー関数形式に書き換えた以外は概ね https://developer.chrome.com/extensions/options のままです。

prefixの設定がされていない場合に参照される https://github.com/koron/JustTweet/blob/557767260a5cd6e6fc749b695aaaee30d7a06afe/src/settings/settings.js#L18 を`' » '`とベタ書きしようとすると、オプション画面のtextboxに代入される際になぜか` Â» `と化けてしまいうまくいかなかったため、ユニコードの数値参照に書き換えました。